### PR TITLE
CentOS and RHEL do have the utils-linux package

### DIFF
--- a/recipes/affinity.rb
+++ b/recipes/affinity.rb
@@ -19,7 +19,6 @@
 
 case node['platform_family']
 when 'debian'
-  package 'util-linux'
 when 'rhel'
-  package 'schedutils'
+  package 'util-linux'
 end


### PR DESCRIPTION
CentOS 7.2 was returning an error being unable to locate the 'schedutils' package.
Substituted with the available 'utils-linux'.
Tested on CentOS 6.7 as well.
